### PR TITLE
Handling of [COURSE TEXT] and migration to Python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ ERG/MRC to Zwift Workout File, based on code posted to this blog https://fukawit
         -m        Skip Course Text conversion.
 ```
 
+For example:
+
+```
+python zerg.py path/to/workout.mrc
+```
+
+See also http://kb.zwiftriders.com/convert-sufferfest-to-Zwift
+
 # ZWO Tag Syntax Documentation
 In an effort to better understand the format that is needed for Zwift to correctly accept the files this script creates, here is some reverse engineered documentation.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,38 @@
 # Zerg zwo Converter
 ERG/MRC to Zwift Workout File, based on code posted to this blog https://fukawitribe.wordpress.com/2015/12/15/zerg-ergmrc-to-zwift-workout-file/
 
+# Usage
+
+```
+        zerg [options] file1.mrc [file2.mrc ...]
+
+        Convert one or more ERG/MRC files to Zwift Workout (zwo) files.
+        Currently only MRC files are supported (workouts are relative to
+        FTP, effort is NOT defined in Watts).
+
+        Options :
+
+        -D <dir>  Place all converted files into directory <dir>.
+                  Default is to write the converted data file to
+                  the same directory as the original data file.
+
+        -h        Help. Show this page and exit.
+
+        -o <name> Save converted file to <name>. Default is to
+                  name the converted data file the same as the
+                  original data file except for the extension
+                  which will be changed to '.zwo', e.g.
+
+                       example.mrc -> example.zwo
+
+                  This obviously only makes sense when one file
+                  is being converted. No check is made that the
+                  converted data file name is different from the
+                  original data file name currently - beware.
+
+        -m        Skip Course Text conversion.
+```
+
 # ZWO Tag Syntax Documentation
 In an effort to better understand the format that is needed for Zwift to correctly accept the files this script creates, here is some reverse engineered documentation.
 
@@ -22,3 +54,4 @@ An interval that slowly decreases the power required throughout the duration of 
   - Duration: Time of Interval, in seconds
   - PowerLow: % of FTP for the start of the cooldown divided by 100
   - PowerHigh: % of FTP for the end of the cooldown divided by 100
+****

--- a/zerg.py
+++ b/zerg.py
@@ -64,12 +64,12 @@ class ErgParser :
             strm.write( '%s\n' % MiniDom.parseString( XmlDoc.tostring( self.rootNode, 'utf-8')
                                    ).toprettyxml(indent="    ") )
             strm.close()
-        except Exception, err :
+        except Exception as err :
             raise Exception( "Error writing output file %s : " % ( outputFile, err ) )
-        
+
     def parser( self ) :
         return self.parsers[-1]
-    
+
     def startOfSection( self, line ) :
         match = self.sectionStartRe.match( line )
         if match :
@@ -130,8 +130,9 @@ class ErgParser :
             elif len( tokens ) == 2 :
                 try :
                     self.addNode( headerTokens[ tokens[0].strip() ], tokens[1] )
-                except Exception, err :
-                    print "Muuuh : %s" % err
+                except Exception as err :
+                    print("Muuuh : {0}".format(str(err)))
+                    #print "Muuuh : %s" % err
                     pass
 
     #-----------------------------
@@ -144,7 +145,7 @@ class ErgParser :
     def dataEnd( self ) :
         if self.data :
             numPoints = len( self.data )
-            print "Data points : %d" % numPoints
+            print("Data points : %d" % numPoints)
 
             # numPoints == 1 is a special case (time datum must be non-negative)
             # Deal with that later,
@@ -152,23 +153,23 @@ class ErgParser :
             for currTime, currEffort in self.data[1:] :
                 duration = currTime - prevTime
                 deltaEffort = currEffort - prevEffort
-                print "Duration = %.3f, start = %.3f, end = %.3f (D = %.3f)" % (
-                    duration, prevEffort, currEffort, deltaEffort )
+                print("Duration = %.3f, start = %.3f, end = %.3f (D = %.3f)" % (
+                    duration, prevEffort, currEffort, deltaEffort ))
 
-            
+
                 if duration :
                     # Increasing effort is 'Warmup' in Zwift parlance, decreasing effort
                     # is 'Cooldown' and no change is 'SteadyState' (note case).
                     intervalType = 'SteadyState'
                     if   deltaEffort > 0 : intervalType = 'Warmup'
                     elif deltaEffort < 0 : intervalType = 'Cooldown'
-                    
+
                     interval = self.addInterval( intervalType, duration, prevEffort, currEffort )
-                
+
                 # .. and around we go again
                 prevTime = currTime
                 prevEffort = currEffort
-                
+
         del self.data
 
     def dataParse( self, line ) :
@@ -186,20 +187,20 @@ class ErgParser :
     def textStart( self ) : pass
     def textEnd( self ) : pass
     def textParse( self, line ) :
-        print '%s' % line
+        print('%s' % line)
 
-        
+
     def parse( self, path ) :
         try :
             for line in open( path ) :
-                print "Parser '%s', line : %s" % ( self.parser(), line )
+                print("Parser '%s', line : %s" % ( self.parser(), line ))
                 self.parser()( line )
 
-        except Exception, err :
-            print 'Muuuh : %s' % err
+        except Exception as err :
+            print('Muuuh : %s' % err)
         finally :
             self.write()
-                
+
 #---------------------------------------------------------
 # Mainline - options parsing and drivers
 #---------------------------------------------------------
@@ -207,7 +208,7 @@ if __name__ == '__main__' :
     import getopt
 
     def printUsage() :
-        print """
+        print("""
         zerg [options] file1.mrc [file2.mrc ...]
 
         Convert one or more ERG/MRC files to Zwift Workout (zwo) files.
@@ -234,8 +235,8 @@ if __name__ == '__main__' :
                   converted data file name is different from the
                   original data file name currently - beware.
 
-        """
-        
+        """)
+
 
     optFileType = None
     optFileOutput = None
@@ -245,19 +246,19 @@ if __name__ == '__main__' :
         'erg' : ( 'ERG file', 'WATTS' ) ,
         'mrc' : ( 'MRC file', 'PERCENT' )
         }
-    
+
     try :
         opts, files = getopt.getopt( sys.argv[1:], "D:ho:t:" )
 
-    except getopt.GetoptError, msg :
-        print "Invalid option(s) : %s" % msg
+    except getopt.GetoptError as msg :
+        print("Invalid option(s) : %s" % msg)
         printUsage()
         sys.exit( 1 )
 
-    except Exception, err :
-        print "Internal error, exiting : %s" % err
+    except Exception as err :
+        print("Internal error, exiting : %s" % err)
         sys.exit( 2 )
-    
+
     else :
         for opt, val in opts :
             if opt == '-D' :
@@ -270,19 +271,13 @@ if __name__ == '__main__' :
             elif opt == '-t' :
                 try :
                     desc, _ = fileTypes[ val ]
-                    print "Forcing file type to '%s' (%s)" % ( val, desc )
+                    print("Forcing file type to '%s' (%s)" % ( val, desc ))
                     optFileType = val
                 except :
-                    print "Invalid file type '%s', should be one of %s" % (
-                        val, ', '.join( fileTypes.keys() ) )
+                    print("Invalid file type '%s', should be one of %s" % (
+                        val, ', '.join( fileTypes.keys() ) ))
                     sys.exit( 3 )
 
         for path in files :
             ErgParser( path,
                        fileType = optFileType, fileOutput = optFileOutput, outputDir = optOutputDir )
-
-
-                
-
-
-

--- a/zerg.py
+++ b/zerg.py
@@ -283,7 +283,7 @@ if __name__ == '__main__' :
         opts, files = getopt.getopt( sys.argv[1:], "D:ho:t:m" )
 
     except getopt.GetoptError as msg :
-        print("Invalid option(s) : %s" % msg)
+        print("Invalid option(s) : %s" % msg)   
         printUsage()
         sys.exit( 1 )
 

--- a/zerg.py
+++ b/zerg.py
@@ -33,6 +33,7 @@ import xml.etree.ElementTree as XmlDoc
 import xml.dom.minidom as MiniDom
 
 class ErgParser :
+    # sectionStartRe = re.compile( '\[(?P<tag>.*?)\]' )
     sectionStartRe = re.compile( '[[](?P<tag>[^]]+)[]].*' )
     sectionEndRe = re.compile( '[[]END (?P<tag>[^]]+)[]].*' )
 
@@ -129,10 +130,12 @@ class ErgParser :
                 pass
             elif len( tokens ) == 2 :
                 try :
-                    self.addNode( headerTokens[ tokens[0].strip() ], tokens[1] )
+                    # Use filename as Zwift name if input is 'none'
+                    if tokens[0].strip() == 'FILE NAME' and tokens[1].strip() == 'none':
+                        tokens[1] = os.path.splitext(os.path.basename(self.input))[0]
+                    self.addNode( headerTokens[ tokens[0].strip() ], tokens[1].strip() )
                 except Exception as err :
                     print("Muuuh : {0}".format(str(err)))
-                    #print "Muuuh : %s" % err
                     pass
 
     #-----------------------------

--- a/zerg.py
+++ b/zerg.py
@@ -112,6 +112,20 @@ class ErgParser :
         node.text = value
         return node
 
+    def addText( self, interval, timeOffset, message):
+        # Iterate through all nodes in workout and add text when needed
+        periodStart = 0.0
+        periodEnd = 0.0
+        for child in self.rootNode.find('workout'):
+            periodEnd += float(child.attrib['Duration'])
+
+            if (interval >= periodStart) & (interval < periodEnd):
+                XmlDoc.SubElement( child, 'textevent', message = message, timeoffset = "%f" % timeOffset )
+                break
+
+            periodStart = periodEnd
+        pass
+
     #-----------------------------
     # Course Header
     #-----------------------------
@@ -190,7 +204,17 @@ class ErgParser :
     def textStart( self ) : pass
     def textEnd( self ) : pass
     def textParse( self, line ) :
-        print('%s' % line)
+        # print('%s' % line)
+        if not self.endOfSection( line ) :
+            tokens = re.split(r'\t+', line.rstrip())
+            if len (tokens) == 8 :
+                interval = float(tokens[0])
+                message = tokens[1]
+                timeOffset = float(tokens[7])
+                # print('%s (at %s + %s)' % (message, interval, timeOffset))
+
+            self.addText(interval, timeOffset, message)
+        pass
 
 
     def parse( self, path ) :

--- a/zerg.py
+++ b/zerg.py
@@ -264,11 +264,6 @@ if __name__ == '__main__' :
                   converted data file name is different from the
                   original data file name currently - beware.
 
-        -t <type> Force file type of input files. <Type> can be one of:
-        
-                     - erg - ERG file. Intervals defined by Watts
-                     - mrc - MRC file. Intervals defined by % of FTP.
-
         -m        Skip Course Text conversion.
 
         """)


### PR DESCRIPTION
Hi,

Biggest changes:
* Update to Python3
* Handling of [COURSE TEXT] tags, i.e. conversion

```
[COURSE TEXT]
0	Message 1	5	0	0	72	16777215	10
0	Message2	4	0	0	72	16777215	17
```

to

```
    <workout>
        <SteadyState Duration="150.0" PowerHigh="0.500" PowerLow="0.500">
            <textevent message="Message 1" timeoffset="10.000000"/>
            <textevent message="Message 2" timeoffset="17.000000"/>
```
* In case when workout name is set to `none`, workout filename (w/o extension) will be used

I'm not sure if you're still maintaining this repository but perhaps worth to merge.

Thank you,
Jarek